### PR TITLE
feat: 🎸 support for custom datasets

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -265,7 +265,7 @@ generated-members=
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=150
+max-line-length=160
 
 # TODO(https://github.com/PyCQA/pylint/issues/3352): Direct pylint to exempt
 # lines made too long by directives to pytype.

--- a/TODO.md
+++ b/TODO.md
@@ -11,3 +11,4 @@
     - Configuration Document
     - Cutomized Loss
     - Utils
+    - How to define custom datasets.

--- a/basicts/runners/base_tsf_runner.py
+++ b/basicts/runners/base_tsf_runner.py
@@ -93,14 +93,20 @@ class BaseTimeSeriesForecastingRunner(BaseRunner):
             train dataset (Dataset)
         """
 
-        raw_file_path = "{0}/data_in{1}_out{2}.pkl".format(cfg["TRAIN"]["DATA"]["DIR"], cfg["DATASET_INPUT_LEN"], cfg["DATASET_OUTPUT_LEN"])
-        index_file_path = "{0}/index_in{1}_out{2}.pkl".format(
-            cfg["TRAIN"]["DATA"]["DIR"], cfg["DATASET_INPUT_LEN"], cfg["DATASET_OUTPUT_LEN"])
-        batch_size = cfg["TRAIN"]["DATA"]["BATCH_SIZE"]
-        dataset = cfg["DATASET_CLS"](
-            raw_file_path, index_file_path, mode="train")
+        data_file_path = "{0}/data_in{1}_out{2}.pkl".format(cfg["TRAIN"]["DATA"]["DIR"], cfg["DATASET_INPUT_LEN"], cfg["DATASET_OUTPUT_LEN"])
+        index_file_path = "{0}/index_in{1}_out{2}.pkl".format(cfg["TRAIN"]["DATA"]["DIR"], cfg["DATASET_INPUT_LEN"], cfg["DATASET_OUTPUT_LEN"])
+
+        # build dataset args
+        dataset_args = cfg.get("DATASET_ARGS", dict())
+        # three necessary arguments, data file path, corresponding index file path, and mode (train, valid, or test)
+        dataset_args["data_file_path"] = data_file_path
+        dataset_args["index_file_path"] = index_file_path
+        dataset_args["mode"] = "train"
+
+        dataset = cfg["DATASET_CLS"](**dataset_args)
         print("train len: {0}".format(len(dataset)))
 
+        batch_size = cfg["TRAIN"]["DATA"]["BATCH_SIZE"]
         self.iter_per_epoch = math.ceil(len(dataset) / batch_size)
 
         return dataset
@@ -115,13 +121,19 @@ class BaseTimeSeriesForecastingRunner(BaseRunner):
         Returns:
             validation dataset (Dataset)
         """
+        data_file_path = "{0}/data_in{1}_out{2}.pkl".format(cfg["VAL"]["DATA"]["DIR"], cfg["DATASET_INPUT_LEN"], cfg["DATASET_OUTPUT_LEN"])
+        index_file_path = "{0}/index_in{1}_out{2}.pkl".format(cfg["VAL"]["DATA"]["DIR"], cfg["DATASET_INPUT_LEN"], cfg["DATASET_OUTPUT_LEN"])
 
-        raw_file_path = "{0}/data_in{1}_out{2}.pkl".format(cfg["VAL"]["DATA"]["DIR"], cfg["DATASET_INPUT_LEN"], cfg["DATASET_OUTPUT_LEN"])
-        index_file_path = "{0}/index_in{1}_out{2}.pkl".format(
-            cfg["VAL"]["DATA"]["DIR"], cfg["DATASET_INPUT_LEN"], cfg["DATASET_OUTPUT_LEN"])
-        dataset = cfg["DATASET_CLS"](
-            raw_file_path, index_file_path, mode="valid")
+        # build dataset args
+        dataset_args = cfg.get("DATASET_ARGS", dict())
+        # three necessary arguments, data file path, corresponding index file path, and mode (train, valid, or test)
+        dataset_args["data_file_path"] = data_file_path
+        dataset_args["index_file_path"] = index_file_path
+        dataset_args["mode"] = "valid"
+
+        dataset = cfg["DATASET_CLS"](**dataset_args)
         print("val len: {0}".format(len(dataset)))
+
         return dataset
 
     @staticmethod
@@ -135,12 +147,19 @@ class BaseTimeSeriesForecastingRunner(BaseRunner):
             train dataset (Dataset)
         """
 
-        raw_file_path = "{0}/data_in{1}_out{2}.pkl".format(cfg["TEST"]["DATA"]["DIR"], cfg["DATASET_INPUT_LEN"], cfg["DATASET_OUTPUT_LEN"])
-        index_file_path = "{0}/index_in{1}_out{2}.pkl".format(
-            cfg["TEST"]["DATA"]["DIR"], cfg["DATASET_INPUT_LEN"], cfg["DATASET_OUTPUT_LEN"])
-        dataset = cfg["DATASET_CLS"](
-            raw_file_path, index_file_path, mode="test")
+        data_file_path = "{0}/data_in{1}_out{2}.pkl".format(cfg["TEST"]["DATA"]["DIR"], cfg["DATASET_INPUT_LEN"], cfg["DATASET_OUTPUT_LEN"])
+        index_file_path = "{0}/index_in{1}_out{2}.pkl".format(cfg["TEST"]["DATA"]["DIR"], cfg["DATASET_INPUT_LEN"], cfg["DATASET_OUTPUT_LEN"])
+
+        # build dataset args
+        dataset_args = cfg.get("DATASET_ARGS", dict())
+        # three necessary arguments, data file path, corresponding index file path, and mode (train, valid, or test)
+        dataset_args["data_file_path"] = data_file_path
+        dataset_args["index_file_path"] = index_file_path
+        dataset_args["mode"] = "test"
+
+        dataset = cfg["DATASET_CLS"](**dataset_args)
         print("test len: {0}".format(len(dataset)))
+
         return dataset
 
     def curriculum_learning(self, epoch: int = None) -> int:


### PR DESCRIPTION
The dataset must receive three arguments: data_file_path, index_file_path, mode. BasicTS automatically generates these three parameters and passes them to the Dataset. Other parameters can be defined in the CFG.DATASET_ARGS dictionary. If the above three necessary parameters are defined in the dictionary, BasicTS will use the CFG.DATASET_ARGS dictionary as the standard.