### PR TITLE
Fix bug: Moving the adj matrix to the same device as the model. (STGCN GraphConv)

### DIFF
--- a/basicts/archs/arch_zoo/stgcn_arch/stgcn_layers.py
+++ b/basicts/archs/arch_zoo/stgcn_arch/stgcn_layers.py
@@ -223,6 +223,8 @@ class GraphConv(nn.Module):
         #bs, c_in, ts, n_vertex = x.shape
         x = torch.permute(x, (0, 2, 3, 1))
 
+        self.gso = self.gso.to(x.device)
+
         first_mul = torch.einsum('hi,btij->bthj', self.gso, x)
         second_mul = torch.einsum('bthi,ij->bthj', first_mul, self.weight)
 


### PR DESCRIPTION
A small bug I stumbled across when using your code.
I fixed it in the same way as in the default convolution `ChebGraphConv`.